### PR TITLE
Updated to support CocoaLumberjack 2.x.

### DIFF
--- a/Classes/FLAVerboseLogFormatter.m
+++ b/Classes/FLAVerboseLogFormatter.m
@@ -49,30 +49,34 @@
     @autoreleasepool
     {
         NSString *logLevel;
-        switch (logMessage->logFlag)
+        switch (logMessage->_flag)
         {
-            case LOG_FLAG_ERROR:
-                logLevel = @"[Error]"; break;
-            case LOG_FLAG_WARN:
-                logLevel = @"[Warn]"; break;
-            case LOG_FLAG_INFO:
-                logLevel = @"[Info]"; break;
-            default:
-                logLevel = @"[Verbose]"; break;
+            case DDLogFlagError:
+                logLevel = @"[Error]";
+                break;
+            case DDLogFlagWarning:
+                logLevel = @"[Warn]";
+                break;
+            case DDLogFlagInfo:
+                logLevel = @"[Info]";
+                break;
+            case DDLogFlagDebug:
+                logLevel = @"[Debug]";
+                break;
+            case DDLogFlagVerbose:
+                logLevel = @"[Verbose]";
+                break;
         }
         
-        NSDate *timestamp = logMessage->timestamp;
+        NSDate *timestamp = logMessage->_timestamp;
         
         [_dateFormatterLock lock];
         NSString *dateAndTime = [_dateFormatter stringFromDate:timestamp];
         [_dateFormatterLock unlock];
         
-        NSString *filePath = [[NSString alloc] initWithCString:logMessage->file encoding:NSUTF8StringEncoding];
-        NSString *fileName = [[filePath lastPathComponent] stringByDeletingPathExtension];
+        NSString *logMsg = logMessage->_message;
         
-        NSString *logMsg = logMessage->logMsg;
-        
-        NSString *logMessageString = [NSString stringWithFormat:@"%@ %@ (%s)%@: %@\n", dateAndTime, fileName, logMessage->function, logLevel, logMsg];
+        NSString *logMessageString = [NSString stringWithFormat:@"%@ %@ (%s)%@: %@\n", dateAndTime, logMessage->_fileName, logMessage->_function, logLevel, logMsg];
         
         copy = [logMessageString copy];
     }

--- a/Flannel.podspec
+++ b/Flannel.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Flannel"
-  s.version      = "1.0.1"
+  s.version      = "1.0.2"
   s.summary      = "Flannel is a stylish log formatter for CocoaLumberjack"
   s.description  = <<-DESC
                     Flannel is a stylish log formatter for CocoaLumberjack. Flannel is thread safe and formats your CocoaLumberjack log statements so that you know the class and method from which your log statement originated.
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.ios.platform   = :ios, '7.0'
   s.osx.platform   = :osx, '10.9'
 
-  s.dependency 'CocoaLumberjack', '~> 1.8.1'
+  s.dependency 'CocoaLumberjack', '> 1.9.2'
 
   s.source_files = 'Classes/'
   


### PR DESCRIPTION
Currently, CocoaLumberjack has a prerelease version out for 2.0 which is used by default if your podfile doesn't explicitly specify an earlier version. I tried to make the dependency in the podspec '~> 2.0' so it would match 2.0.x, 2.x, but not 3.x, but it wasn't matching the current CocoaLumberjack version tags which are named like "2.0.0-beta", "2.0.0-beta2", "2.0.0-rc", etc. I think it had a problem with the dash suffix. So, I made it specify '> 1.9.2' (1.9.2 is the last 1.x version). Shouldn't be an issue until CocoaLumberjack 3.x comes out since it will still match 3.x versions.

Also, I'm not sure how you wanted to handle the Flannel version number. I just bumped it to 1.0.2.
