### PR TITLE
Updated podspec CocoaLumberjack dependency version

### DIFF
--- a/Flannel.podspec
+++ b/Flannel.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Flannel"
-  s.version      = "2.0.1"
+  s.version      = "2.0.2"
   s.summary      = "Flannel is a stylish log formatter for CocoaLumberjack"
   s.description  = <<-DESC
                     Flannel is a stylish log formatter for CocoaLumberjack. Flannel is thread safe and formats your CocoaLumberjack log statements so that you know the class and method from which your log statement originated.
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Pod/Classes'
   
-  s.dependency 'CocoaLumberjack', '~> 2.0.0-rc'
+  s.dependency 'CocoaLumberjack', '~> 2.0'
 end


### PR DESCRIPTION
When attempting to use the latest version of Flannel with version 2.2.0 of CococaLumberjack, I'm getting this error on pod install:

```
[!] Unable to satisfy the following requirements:

- `CocoaLumberjack/Extensions (= 2.2.0)` required by `Podfile.lock`
- `CocoaLumberjack/Extensions (= 2.0.0-rc)` required by `CocoaLumberjack (2.0.0-rc)`

Specs satisfying the `CocoaLumberjack/Extensions (= 2.2.0)` dependency were found, but they required a higher minimum deployment target.
```

I think the '~>' operator takes issue with that -rc suffix. I changed the dependency version to just be '~> 2.0' so it will work with any 2.x version of CocoaLumberjack regardless of the minor version. It looks like they've been incrementing the minor version for newer versions of Swift. I think the current version of Flannel should be compatible with any 2.x version.
